### PR TITLE
Pointer to virtual member functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,126 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Right
+AlignOperands:   false
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     90
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentPPDirectives: AfterHash
+IndentWidth:     4
+IndentWrappedFunctionNames: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseTab:          Never
+...

--- a/CallbackConnector.h
+++ b/CallbackConnector.h
@@ -1,16 +1,20 @@
 #ifndef CALLBACKCONNECTOR_H
 #define CALLBACKCONNECTOR_H
+
 #include <functional>
-namespace cbc{
+
+namespace cbc {
 namespace Details {
 
-template <std::size_t Tag, typename T, typename Ret, typename... Args>
+template<std::size_t Tag, typename T, typename Ret, typename... Args>
 class FuncMemberWrapper
 {
 public:
     FuncMemberWrapper() = delete;
-    using member_fun_t =  Ret(T::*)(Args...);
-    using const_member_fun_t =  Ret(T::*)(Args...) const;
+    FuncMemberWrapper(const FuncMemberWrapper&) = delete;
+    FuncMemberWrapper(FuncMemberWrapper&&) = delete;
+    using member_fun_t = Ret (T::*)(Args...);
+    using const_member_fun_t = Ret (T::*)(Args...) const;
     static auto instantiate(T* t, member_fun_t ptr)
     {
         obj = t;
@@ -24,94 +28,87 @@ public:
         const_member = ptr;
         return ConstMetaCall;
     }
+
 private:
     static auto MetaCall(Args... args)
     {
-         return (*obj.*member)(args...);
+        return (*obj.*member)(args...);
     }
     static auto ConstMetaCall(Args... args)
     {
-         return (*obj.*const_member)(args...);
+        return (*obj.*const_member)(args...);
     }
-    static T* obj;
-    static member_fun_t member;
+    static T*                 obj;
+    static member_fun_t       member;
     static const_member_fun_t const_member;
 };
-template <std::size_t Tag, typename T, typename Ret, typename... Args>
+template<std::size_t Tag, typename T, typename Ret, typename... Args>
 T* FuncMemberWrapper<Tag, T, Ret, Args...>::obj{};
 
-template <std::size_t Tag, typename T, typename Ret, typename... Args>
-typename FuncMemberWrapper<Tag, T, Ret, Args...>::member_fun_t FuncMemberWrapper<Tag, T, Ret, Args...>::member{};
+template<std::size_t Tag, typename T, typename Ret, typename... Args>
+typename FuncMemberWrapper<Tag, T, Ret, Args...>::member_fun_t
+    FuncMemberWrapper<Tag, T, Ret, Args...>::member{};
 
-template <std::size_t Tag, typename T, typename Ret, typename... Args>
-typename FuncMemberWrapper<Tag, T, Ret, Args...>::const_member_fun_t FuncMemberWrapper<Tag, T, Ret, Args...>::const_member{};
+template<std::size_t Tag, typename T, typename Ret, typename... Args>
+typename FuncMemberWrapper<Tag, T, Ret, Args...>::const_member_fun_t
+    FuncMemberWrapper<Tag, T, Ret, Args...>::const_member{};
 
-template <typename Functor, typename Ret, typename... Args>
+template<typename Functor, typename Ret, typename... Args>
 struct FunctorWrapper
 {
 public:
-    static std::function<Ret(Args...)> functor;
-    static auto instatiate(Functor fn)
+    FunctorWrapper() = delete;
+    FunctorWrapper(const FunctorWrapper&) = delete;
+    FunctorWrapper(FunctorWrapper&&) = delete;
+    static auto instantiate(Functor fn)
     {
-        functor = std::move(fn);
+        m_functor = std::move(fn);
         return MetaCall;
     }
+
 private:
+    static std::function<Ret(Args...)> m_functor;
+
     static auto MetaCall(Args... args)
     {
-         return functor(args...);
+        return m_functor(args...);
     }
 };
 
-template <typename Functor,  typename Ret, typename... Args>
-std::function<Ret(Args...)> FunctorWrapper<Functor, Ret, Args...>::functor;
+template<typename Functor, typename Ret, typename... Args>
+std::function<Ret(Args...)> FunctorWrapper<Functor, Ret, Args...>::m_functor;
 
-
-template <typename Functor, typename Ret, typename T, typename... Args>
-auto deducer(Functor obj, Ret(T::*)(Args...)const)
+template<typename Functor, typename Ret, typename T, typename... Args>
+auto deducer(Functor obj, Ret (T::*)(Args...) const)
 {
-    return FunctorWrapper<Functor, Ret, Args...>::instatiate(std::move(obj));
+    return FunctorWrapper<Functor, Ret, Args...>::instantiate(std::move(obj));
 }
 
-template <typename Functor, typename Ret, typename T, typename... Args>
-auto deducer(Functor obj, Ret(T::*)(Args...))
+template<typename Functor, typename Ret, typename T, typename... Args>
+auto deducer(Functor obj, Ret (T::*)(Args...))
 {
-    return FunctorWrapper<Functor, Ret, Args...>::instatiate(std::move(obj));
+    return FunctorWrapper<Functor, Ret, Args...>::instantiate(std::move(obj));
 }
 
-template <std::size_t tag, typename T, typename Ret, typename... Args>
-auto const_instantiate(T* t, Ret(T::*ptr)(Args...) const)
-{
-    return FuncMemberWrapper<tag, T, Ret, Args...>::instantiate(t, ptr);
-}
+} // namespace Details
 
-template <std::size_t tag, typename T, typename Func>
-auto const_instantiate(T* t, Func ptr)
-{
-    return const_instantiate(t, ptr);
-}
-
-} //end of Details scope
-
-
-template <std::size_t tag = 0, typename T, typename Ret, typename... Args>
-auto obtain_connector(T* t, Ret(T::*ptr)(Args...))
-{
-    return Details::FuncMemberWrapper<tag, T, Ret, Args...>::instantiate(t, ptr);
-
-}
-
-template <std::size_t tag = 0, typename T, typename Ret, typename... Args>
-auto obtain_connector(T* t, Ret(T::*ptr)(Args...) const)
+template<std::size_t tag = 0, typename T, typename Ret, typename... Args, typename U>
+auto obtain_connector(T* t, Ret (U::*ptr)(Args...))
 {
     return Details::FuncMemberWrapper<tag, T, Ret, Args...>::instantiate(t, ptr);
 }
 
-template <typename Functor>
+template<std::size_t tag = 0, typename T, typename Ret, typename... Args, typename U>
+auto obtain_connector(T* t, Ret (U::*ptr)(Args...) const)
+{
+    return Details::FuncMemberWrapper<tag, T, Ret, Args...>::instantiate(t, ptr);
+}
+
+template<typename Functor>
 auto obtain_connector(Functor functor)
 {
     return Details::deducer(std::move(functor), &Functor::operator());
 }
-} //end of cbc scope
+} // namespace cbc
 
 #endif // CALLBACKCONNECTOR_H

--- a/README.md
+++ b/README.md
@@ -78,8 +78,14 @@ int main()
     auto virtual_ptr = obtain_connector(&child, &Foo::some_virtual);
     c_api_func_with_callback(virtual_ptr);
 
+    virtual_ptr = obtain_connector(&obj, &Foo::some_virtual);
+    c_api_func_with_callback(virtual_ptr);
+
     // const virtual member function
     auto const_virtual_ptr = obtain_connector(&child, &Foo::const_virtual);
+    c_api_func_with_callback(const_virtual_ptr);
+
+    const_virtual_ptr = obtain_connector(&obj, &Foo::const_virtual);
     c_api_func_with_callback(const_virtual_ptr);
 
     // inherited non-virtual member function
@@ -98,5 +104,4 @@ int main()
 
     return 0;
 }
-
 ```

--- a/README.md
+++ b/README.md
@@ -1,57 +1,102 @@
-# Callback Connector  
+# Callback Connector
 ## Description
-Tiny **header-only** library that allows passing member function and lambdas as C-Api callbacks  
-## Usage  
+Tiny **header-only** library that allows passing member function and lambdas as C-Api callbacks
+## Usage
 1. Include `CallbackConnector.h` into your project
 2. Use `cbc::obtain_connector` function to retrieve C-Api function pointer
 3. Pass obtained pointer as callback function
 ### Example:
 ```C++
-#include <iostream>
 #include "CallbackConnector.h"
 
-//callback type
-using cb_t = void(*)();
+#include <iostream>
 
-//function that takes pointer to function as callback
+using cb_t = void (*)();
+
 void c_api_func_with_callback(cb_t cb)
 {
     cb();
 }
 
-//class mith members you want to pass
 struct Foo
 {
-    void some_member() {std::cout << "some_member " << std::endl;}
-    void const_member() const {std::cout << "const_member" << std::endl;}
-    void another_member_with_same_signature() {std::cout << "another_member_with_same_signature" << std::endl;}
+    void some_member()
+    {
+        std::cout << "some_member" << std::endl;
+    }
+    void const_member() const
+    {
+        std::cout << "const_member" << std::endl;
+    }
+    void another_member_with_same_signature()
+    {
+        std::cout << "another_member_with_same_signature" << std::endl;
+    }
+    virtual void some_virtual()
+    {
+        std::cout << "some_virtual Foo" << std::endl;
+    }
+    virtual void const_virtual() const
+    {
+        std::cout << "const_virtual Foo" << std::endl;
+    }
+};
+
+struct Boo : Foo
+{
+    virtual void some_virtual() override
+    {
+        std::cout << "some_virtual Boo" << std::endl;
+    }
+    virtual void const_virtual() const override
+    {
+        std::cout << "const_virtual Boo" << std::endl;
+    }
 };
 
 int main()
 {
     Foo obj;
     using namespace cbc;
-    //you can omit non-type Tag parameter if you are using member function with unique signature
+    // you can omit non-type Tag parameter if you are using member function with
+    // unique signature
     auto func_ptr = obtain_connector(&obj, &Foo::some_member);
     c_api_func_with_callback(func_ptr);
 
-
     Foo obj2;
-    //use Tag parameter to disambiguate call
-    auto new_func_ptr = obtain_connector<1>(&obj2, &Foo::another_member_with_same_signature);
+    // use Tag parameter to disambiguate call
+    auto new_func_ptr =
+        obtain_connector<1>(&obj2, &Foo::another_member_with_same_signature);
     c_api_func_with_callback(new_func_ptr);
 
-
-    //you can use const member functions as well
+    // you can use const member functions as well
     auto const_ptr = obtain_connector(&obj2, &Foo::const_member);
     c_api_func_with_callback(const_ptr);
 
+    Boo child;
+    // polymorphism works
+    auto virtual_ptr = obtain_connector(&child, &Foo::some_virtual);
+    c_api_func_with_callback(virtual_ptr);
 
-    //usage with capturing lambda
+    // const virtual member function
+    auto const_virtual_ptr = obtain_connector(&child, &Foo::const_virtual);
+    c_api_func_with_callback(const_virtual_ptr);
+
+    // inherited non-virtual member function
+    auto nonvirtual_ptr = obtain_connector(&child, &Foo::some_member);
+    c_api_func_with_callback(nonvirtual_ptr);
+
+    // inherited const non-virtual member function
+    auto const_nonvirtual_ptr = obtain_connector(&child, &Foo::const_member);
+    c_api_func_with_callback(const_nonvirtual_ptr);
+
+    // usage with capturing lambda
     std::string str = "it works";
-    auto capturing_closure_ptr = obtain_connector([str](){ std::cout << str << std::endl;});
+    auto        capturing_closure_ptr =
+        obtain_connector([str]() { std::cout << str << std::endl; });
     c_api_func_with_callback(capturing_closure_ptr);
 
     return 0;
 }
+
 ```

--- a/main.cpp
+++ b/main.cpp
@@ -69,8 +69,14 @@ int main()
     auto virtual_ptr = obtain_connector(&child, &Foo::some_virtual);
     c_api_func_with_callback(virtual_ptr);
 
+    virtual_ptr = obtain_connector(&obj, &Foo::some_virtual);
+    c_api_func_with_callback(virtual_ptr);
+
     // const virtual member function
     auto const_virtual_ptr = obtain_connector(&child, &Foo::const_virtual);
+    c_api_func_with_callback(const_virtual_ptr);
+
+    const_virtual_ptr = obtain_connector(&obj, &Foo::const_virtual);
     c_api_func_with_callback(const_virtual_ptr);
 
     // inherited non-virtual member function

--- a/main.cpp
+++ b/main.cpp
@@ -1,44 +1,90 @@
-#include <iostream>
 #include "CallbackConnector.h"
 
-using cb_t = void(*)();
+#include <iostream>
+
+using cb_t = void (*)();
 
 void c_api_func_with_callback(cb_t cb)
 {
     cb();
 }
 
-
 struct Foo
 {
-    void some_member() {std::cout << "some_member " << std::endl;}
-    void const_member() const {std::cout << "const_member" << std::endl;}
-    void another_member_with_same_signature() {std::cout << "another_member_with_same_signature" << std::endl;}
+    void some_member()
+    {
+        std::cout << "some_member" << std::endl;
+    }
+    void const_member() const
+    {
+        std::cout << "const_member" << std::endl;
+    }
+    void another_member_with_same_signature()
+    {
+        std::cout << "another_member_with_same_signature" << std::endl;
+    }
+    virtual void some_virtual()
+    {
+        std::cout << "some_virtual Foo" << std::endl;
+    }
+    virtual void const_virtual() const
+    {
+        std::cout << "const_virtual Foo" << std::endl;
+    }
+};
+
+struct Boo : Foo
+{
+    virtual void some_virtual() override
+    {
+        std::cout << "some_virtual Boo" << std::endl;
+    }
+    virtual void const_virtual() const override
+    {
+        std::cout << "const_virtual Boo" << std::endl;
+    }
 };
 
 int main()
 {
     Foo obj;
     using namespace cbc;
-    //you can omit non-type Tag parameter if you are using member function with unique signature
+    // you can omit non-type Tag parameter if you are using member function with
+    // unique signature
     auto func_ptr = obtain_connector(&obj, &Foo::some_member);
     c_api_func_with_callback(func_ptr);
 
-
     Foo obj2;
-    //use Tag parameter to disambiguate call
-    auto new_func_ptr = obtain_connector<1>(&obj2, &Foo::another_member_with_same_signature);
+    // use Tag parameter to disambiguate call
+    auto new_func_ptr =
+        obtain_connector<1>(&obj2, &Foo::another_member_with_same_signature);
     c_api_func_with_callback(new_func_ptr);
 
-
-    //you can use const member functions as well
+    // you can use const member functions as well
     auto const_ptr = obtain_connector(&obj2, &Foo::const_member);
     c_api_func_with_callback(const_ptr);
 
+    Boo child;
+    // polymorphism works
+    auto virtual_ptr = obtain_connector(&child, &Foo::some_virtual);
+    c_api_func_with_callback(virtual_ptr);
 
-    //usage with capturing lambda
+    // const virtual member function
+    auto const_virtual_ptr = obtain_connector(&child, &Foo::const_virtual);
+    c_api_func_with_callback(const_virtual_ptr);
+
+    // inherited non-virtual member function
+    auto nonvirtual_ptr = obtain_connector(&child, &Foo::some_member);
+    c_api_func_with_callback(nonvirtual_ptr);
+
+    // inherited const non-virtual member function
+    auto const_nonvirtual_ptr = obtain_connector(&child, &Foo::const_member);
+    c_api_func_with_callback(const_nonvirtual_ptr);
+
+    // usage with capturing lambda
     std::string str = "it works";
-    auto capturing_closure_ptr = obtain_connector([str](){ std::cout << str << std::endl;});
+    auto        capturing_closure_ptr =
+        obtain_connector([str]() { std::cout << str << std::endl; });
     c_api_func_with_callback(capturing_closure_ptr);
 
     return 0;


### PR DESCRIPTION
Fixed obtain_connector so it takes not only pointers to member functions of class T, but also virtual and nonvirtual member functions of T's base classes.